### PR TITLE
disable asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 	},
 	"build": {
 		"appId": "com.josephadams.spotify-controller",
+		"asar": false,
 		"mac": {
 			"category": "public.app-category.music",
 			"darkModeSupport": true


### PR DESCRIPTION
Some of the dependencies (`spotify-node-applescript`) don't play nicely with asar because of their use of `__dirname` to locate files, this results in any command using `execFile` to fail when this is bundled into an asar (which is the default for electron-builder).